### PR TITLE
fix(rust): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -180,5 +180,5 @@ p6df::modules::rust::prompt::lang() {
 ######################################################################
 p6df::modules::rust::prompt::env() {
 
-  p6_return_words 'rust' "$CARGO_HOME"
+  p6_return_words 'rust' '$CARGO_HOME'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None